### PR TITLE
bugfix :: pin major aws modules version

### DIFF
--- a/modules/blobstore/README.md
+++ b/modules/blobstore/README.md
@@ -14,7 +14,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-aws-modules/s3-bucket/aws | < 5.0.0 |
-| <a name="module_bucket_read_write_iam_policy"></a> [bucket\_read\_write\_iam\_policy](#module\_bucket\_read\_write\_iam\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | n/a |
+| <a name="module_bucket_read_write_iam_policy"></a> [bucket\_read\_write\_iam\_policy](#module\_bucket\_read\_write\_iam\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | ~> 5.0 |
 
 ## Resources
 

--- a/modules/blobstore/main.tf
+++ b/modules/blobstore/main.tf
@@ -18,7 +18,8 @@ module "bucket" {
 }
 
 module "bucket_read_write_iam_policy" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
 
   name        = "${var.prefix}-data-read-write"
   description = "Data read/write access policy."

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -11,11 +11,11 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_api_srv_iam_role"></a> [api\_srv\_iam\_role](#module\_api\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
-| <a name="module_flower_srv_iam_role"></a> [flower\_srv\_iam\_role](#module\_flower\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
-| <a name="module_migration_job_iam_role"></a> [migration\_job\_iam\_role](#module\_migration\_job\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
-| <a name="module_ui_srv_iam_role"></a> [ui\_srv\_iam\_role](#module\_ui\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
-| <a name="module_worker_srv_iam_role"></a> [worker\_srv\_iam\_role](#module\_worker\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
+| <a name="module_api_srv_iam_role"></a> [api\_srv\_iam\_role](#module\_api\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
+| <a name="module_flower_srv_iam_role"></a> [flower\_srv\_iam\_role](#module\_flower\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
+| <a name="module_migration_job_iam_role"></a> [migration\_job\_iam\_role](#module\_migration\_job\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
+| <a name="module_ui_srv_iam_role"></a> [ui\_srv\_iam\_role](#module\_ui\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
+| <a name="module_worker_srv_iam_role"></a> [worker\_srv\_iam\_role](#module\_worker\_srv\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
 
 ## Resources
 

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -4,10 +4,12 @@ locals {
   ui_service_account_name        = "${var.helm_release_name}-ui-srv"
   worker_service_account_name    = "${var.helm_release_name}-worker-srv"
   flower_service_account_name    = "${var.helm_release_name}-flower-srv"
+
 }
 
 module "api_srv_iam_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-${local.api_service_account_name}"
 
@@ -27,7 +29,8 @@ module "api_srv_iam_role" {
 }
 
 module "migration_job_iam_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-${local.migration_service_account_name}"
 
@@ -47,7 +50,8 @@ module "migration_job_iam_role" {
 }
 
 module "ui_srv_iam_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-${local.ui_service_account_name}"
 
@@ -62,7 +66,8 @@ module "ui_srv_iam_role" {
 }
 
 module "worker_srv_iam_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-${local.worker_service_account_name}"
 
@@ -82,8 +87,9 @@ module "worker_srv_iam_role" {
 }
 
 module "flower_srv_iam_role" {
-  count  = var.flower_enabled ? 1 : 0
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  count   = var.flower_enabled ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-${local.flower_service_account_name}"
 

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_load_balancer_controller_irsa_role"></a> [aws\_load\_balancer\_controller\_irsa\_role](#module\_aws\_load\_balancer\_controller\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | n/a |
+| <a name="module_aws_load_balancer_controller_irsa_role"></a> [aws\_load\_balancer\_controller\_irsa\_role](#module\_aws\_load\_balancer\_controller\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.0 |
 
 ## Resources
 

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -4,7 +4,8 @@ locals {
 }
 
 module "aws_load_balancer_controller_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
 
   role_name = "${var.prefix}-load-balancer-controller"
 


### PR DESCRIPTION
### 📌 Summary
Pin to version 5 for terraform-aws-modules; we can investigate ~> 6 later

### ❓ Ticket / Justification
Why are you making this change?

### 🧪 Test plan
How did you test it?

### 📝 Notes
Anything else (e.g. rollback plan)?
