### PR TITLE
ENG-3627 :: bump helm v3

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -2,3 +2,9 @@ formatter: "markdown table"
 
 recursive:
   enabled: true
+
+# Root `.terraform.lock.hcl` is gitignored but often exists locally after `terraform
+# init`; without this, terraform-docs resolves exact provider versions from the
+# lockfile while CI (no lockfile) emits constraints — CI pre-commit then fails.
+settings:
+  lockfile: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module to deploy dbnl in AWS.
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,10 +13,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.dbnl.cluster_endpoint
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_cert)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", module.dbnl.cluster_name]
       command     = "aws"

--- a/examples/oidc/main.tf
+++ b/examples/oidc/main.tf
@@ -13,10 +13,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.dbnl.cluster_endpoint
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_cert)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", module.dbnl.cluster_name]
       command     = "aws"

--- a/modules/app/.terraform-docs.yml
+++ b/modules/app/.terraform-docs.yml
@@ -1,0 +1,9 @@
+formatter: "markdown table"
+
+# This module’s `.terraform.lock.hcl` is typically gitignored when present; CI has
+# no lockfile. Nested READMEs are generated per-module; without `lockfile: false`
+# here, terraform-docs can still use a local lockfile for provider version cells
+# while CI emits constraints/`n/a` — pre-commit fails. Kept identical across
+# terraform-{aws,azurerm,google}-dbnl.
+settings:
+  lockfile: false

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -211,54 +211,22 @@ resource "helm_release" "dbnl" {
 
   values = [yamlencode(local.values)]
 
-  dynamic "set_sensitive" {
-    for_each = local.admin_enabled ? ["admin-enabled"] : []
-    content {
-      name  = "auth.admin.hashedPassword"
-      value = bcrypt(var.admin_password)
-    }
-  }
-
-  set_sensitive {
-    name  = "auth.devToken.privateKey"
-    value = var.dev_token_private_key
-  }
-
-  set_sensitive {
-    name  = "redis.username"
-    value = var.redis_username
-  }
-
-  set_sensitive {
-    name  = "redis.password"
-    value = var.redis_password
-  }
-
-  set_sensitive {
-    name  = "db.username"
-    value = var.db_username
-  }
-
-  set_sensitive {
-    name  = "db.password"
-    value = var.db_password
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-password"] : []
-    content {
-      name  = "flower.basicAuth.password"
-      value = var.flower_basic_auth_password
-    }
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-username"] : []
-    content {
-      name  = "flower.basicAuth.username"
-      value = var.flower_basic_auth_username
-    }
-  }
+  set_sensitive = concat(
+    [
+      { name = "auth.devToken.privateKey", value = var.dev_token_private_key },
+      { name = "redis.username", value = var.redis_username },
+      { name = "redis.password", value = var.redis_password },
+      { name = "db.username", value = var.db_username },
+      { name = "db.password", value = var.db_password },
+    ],
+    local.admin_enabled ? [
+      { name = "auth.admin.hashedPassword", value = bcrypt(var.admin_password) },
+    ] : [],
+    local.flower_basic_auth_enabled ? [
+      { name = "flower.basicAuth.password", value = var.flower_basic_auth_password },
+      { name = "flower.basicAuth.username", value = var.flower_basic_auth_username },
+    ] : [],
+  )
 
   lifecycle {
     precondition {

--- a/modules/clickhouse/main.tf
+++ b/modules/clickhouse/main.tf
@@ -56,53 +56,19 @@ resource "helm_release" "clickhouse" {
   namespace        = var.helm_release_namespace
   create_namespace = true
 
-  set {
-    name  = "clusterName"
-    value = "dbnl"
-  }
+  set = [
+    { name = "clusterName", value = "dbnl" },
+    { name = "shards", value = 1 },
+    { name = "replicaCount", value = var.replica_count },
+    { name = "resourcesPreset", value = var.resources_preset },
+    { name = "configdFiles.00-config\\.xml", value = templatefile("${path.module}/00-config.xml.tftpl", { region = var.s3_region, bucket = var.s3_bucket }) },
+    { name = "persistence.size", value = "15Gi" },
+    { name = "global.defaultStorageClass", value = "gp2" },
+    { name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn", value = module.clickhouse_iam_role.iam_role_arn },
+  ]
 
-  set {
-    name  = "shards"
-    value = 1
-  }
-
-  set {
-    name  = "replicaCount"
-    value = var.replica_count
-  }
-
-  set {
-    name  = "resourcesPreset"
-    value = var.resources_preset
-  }
-
-  set_sensitive {
-    name  = "auth.username"
-    value = local.username
-  }
-
-  set_sensitive {
-    name  = "auth.password"
-    value = local.password
-  }
-
-  set {
-    name  = "configdFiles.00-config\\.xml"
-    value = templatefile("${path.module}/00-config.xml.tftpl", { region = var.s3_region, bucket = var.s3_bucket })
-  }
-
-  set {
-    name  = "persistence.size"
-    value = "15Gi"
-  }
-
-  set {
-    name  = "global.defaultStorageClass"
-    value = "gp2"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = module.clickhouse_iam_role.iam_role_arn
-  }
+  set_sensitive = [
+    { name = "auth.username", value = local.username },
+    { name = "auth.password", value = local.password },
+  ]
 }

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -26,23 +26,10 @@ resource "helm_release" "aws_load_balancer_controller" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
 
-  set {
-    name  = "clusterName"
-    value = var.cluster_name
-  }
-
-  set {
-    name  = "serviceAccount.create"
-    value = true
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = local.load_balancer_service_account_name
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = module.aws_load_balancer_controller_irsa_role.iam_role_arn
-  }
+  set = [
+    { name = "clusterName", value = var.cluster_name },
+    { name = "serviceAccount.create", value = true },
+    { name = "serviceAccount.name", value = local.load_balancer_service_account_name },
+    { name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn", value = module.aws_load_balancer_controller_irsa_role.iam_role_arn },
+  ]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -12,7 +12,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## 📌 Summary

- Bump `hashicorp/helm` constraint from `~> 2.0` to `~> 3.0` (installed v3.1.1).
- Migrate provider config to v3 syntax: nested `kubernetes {}` / `exec {}` blocks → attribute assignment (`kubernetes = {}`, `exec = {}`).
- Migrate `helm_release` resources to v3 syntax: repeated `set {}` / `set_sensitive {}` blocks → list-of-object attributes (`set = [{...}]`, `set_sensitive = [{...}]`); reworked `dynamic` blocks into `concat(...)` lists.
- Validated locally with `terraform validate` in both `examples/basic` and `examples/oidc` (no cloud API calls / plan run).

Related PRs:
- azurerm: https://github.com/dbnlAI/terraform-azurerm-dbnl/pull/8
- google: https://github.com/dbnlAI/terraform-google-dbnl/pull/7